### PR TITLE
Use mutable self reference in Adapter methods

### DIFF
--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -23,20 +23,20 @@ impl Adapter for DummyAdapter {
     type MigrationType = Migration;
     type Error = ();
 
-    fn current_version(&self) -> Result<Option<Version>, ()> {
+    fn current_version(&mut self) -> Result<Option<Version>, ()> {
         Ok(self.versions.borrow().iter().last().map(|v| *v))
     }
 
-    fn migrated_versions(&self) -> Result<BTreeSet<Version>, ()> {
+    fn migrated_versions(&mut self) -> Result<BTreeSet<Version>, ()> {
         Ok(self.versions.borrow().iter().cloned().collect())
     }
 
-    fn apply_migration(&self, migration: &Migration) -> Result<(), ()> {
+    fn apply_migration(&mut self, migration: &Migration) -> Result<(), ()> {
         self.versions.borrow_mut().insert(migration.version());
         Ok(())
     }
 
-    fn revert_migration(&self, migration: &Migration) -> Result<(), ()> {
+    fn revert_migration(&mut self, migration: &Migration) -> Result<(), ()> {
         self.versions.borrow_mut().remove(&migration.version());
         Ok(())
     }


### PR DESCRIPTION
This would make it easier to use with rusqlite, as `connection.transaction()` requires a mutable reference:

https://github.com/jgallagher/rusqlite/commit/92834951e36eee06dd1fc1482b113338943f0d76

This requires a trivial change to https://github.com/SkylerLipthay/schemamama_postgres.